### PR TITLE
feat: redesign tv search layout

### DIFF
--- a/app/search.tsx
+++ b/app/search.tsx
@@ -18,66 +18,299 @@ import { getCommonResponsiveStyles } from "@/utils/ResponsiveStyles";
 import ResponsiveNavigation from "@/components/navigation/ResponsiveNavigation";
 import ResponsiveHeader from "@/components/navigation/ResponsiveHeader";
 import { DeviceUtils } from "@/utils/DeviceUtils";
-import Logger from '@/utils/Logger';
+import { pinyin } from "pinyin-pro";
+import Logger from "@/utils/Logger";
+import { SearchHistoryManager } from "@/services/storage";
 
-const logger = Logger.withTag('SearchScreen');
+const HOT_SEARCH_KEYWORDS = [
+  "赘婿",
+  "繁城之下",
+  "拆案",
+  "长相思",
+  "王昭君",
+  "王者荣耀",
+  "海天MOCO",
+  "仙剑四",
+];
+
+const LETTER_KEYS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+const NUMBER_KEYS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+const KEYBOARD_KEYS = [...LETTER_KEYS, ...NUMBER_KEYS];
+
+const SPECIAL_KEY_CONFIG = [
+  { label: "空格", type: "space" },
+  { label: "删除", type: "delete" },
+  { label: "清空", type: "clear" },
+  { label: "搜索", type: "search" },
+] as const;
+
+const MAX_HISTORY_ITEMS = 20;
+
+type SpecialKeyType = (typeof SPECIAL_KEY_CONFIG)[number]["type"];
+
+const logger = Logger.withTag("SearchScreen");
 
 export default function SearchScreen() {
   const [keyword, setKeyword] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [searchHistory, setSearchHistory] = useState<string[]>([]);
   const textInputRef = useRef<TextInput>(null);
   const [isInputFocused, setIsInputFocused] = useState(false);
+  const pinyinCacheRef = useRef<Map<string, { full: string; initials: string }>>(new Map());
   const { showModal: showRemoteModal, lastMessage, targetPage, clearMessage } = useRemoteControlStore();
   const { remoteInputEnabled } = useSettingsStore();
   const router = useRouter();
 
-  // 响应式布局配置
   const responsiveConfig = useResponsiveLayout();
   const commonStyles = getCommonResponsiveStyles(responsiveConfig);
   const { deviceType, spacing } = responsiveConfig;
+  const isTv = deviceType === "tv";
 
   useEffect(() => {
-    if (lastMessage && targetPage === 'search') {
+    if (lastMessage && targetPage === "search") {
       logger.debug("Received remote input:", lastMessage);
       const realMessage = lastMessage.split("_")[0];
       setKeyword(realMessage);
       handleSearch(realMessage);
-      clearMessage(); // Clear the message after processing
+      clearMessage();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastMessage, targetPage]);
 
-  // useEffect(() => {
-  //   // Focus the text input when the screen loads
-  //   const timer = setTimeout(() => {
-  //     textInputRef.current?.focus();
-  //   }, 200);
-  //   return () => clearTimeout(timer);
-  // }, []);
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadHistory = async () => {
+      try {
+        const history = await SearchHistoryManager.get();
+        if (isMounted) {
+          setSearchHistory(history);
+        }
+      } catch (historyError) {
+        logger.warn("Failed to load search history:", historyError);
+      }
+    };
+
+    loadHistory();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const normalizePinyinValue = (value: string) =>
+    value
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[üǖǘǚǜ]/g, "v")
+      .replace(/[^a-z]/g, "");
+
+  const getPinyinForms = (text: string) => {
+    if (!text) {
+      return { full: "", initials: "" };
+    }
+
+    const cached = pinyinCacheRef.current.get(text);
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const full = normalizePinyinValue(pinyin(text, { toneType: "none" }));
+      const initials = normalizePinyinValue(pinyin(text, { pattern: "first", toneType: "none" }));
+      const computed = { full, initials };
+      pinyinCacheRef.current.set(text, computed);
+      return computed;
+    } catch (conversionError) {
+      logger.warn("Failed to convert title to pinyin:", text, conversionError);
+      const fallback = { full: "", initials: "" };
+      pinyinCacheRef.current.set(text, fallback);
+      return fallback;
+    }
+  };
+
+  const filterResultsByKeyword = (items: SearchResult[], termValue: string) => {
+    const trimmedTerm = termValue.trim();
+    if (!trimmedTerm) {
+      return items;
+    }
+
+    const lowerTerm = trimmedTerm.toLowerCase();
+    const collapsedTerm = lowerTerm.replace(/\s+/g, "");
+    const lettersOnlyTerm = collapsedTerm.replace(/[^a-z]/g, "");
+    const isPinyinSearch = lettersOnlyTerm.length > 0 && lettersOnlyTerm === collapsedTerm;
+
+    if (!isPinyinSearch) {
+      return items;
+    }
+
+    logger.debug("Applying pinyin filter for keyword:", termValue);
+
+    const rankedMatches = items
+      .map((item, index) => {
+        const title = item.title || "";
+        if (!title) {
+          return { item, index, score: Number.POSITIVE_INFINITY, matched: false };
+        }
+
+        const lowerTitle = title.toLowerCase();
+        if (lowerTitle.includes(lowerTerm)) {
+          return { item, index, score: 0, matched: true };
+        }
+
+        const condensedTitle = lowerTitle.replace(/\s+/g, "");
+        if (condensedTitle.includes(collapsedTerm)) {
+          return { item, index, score: 1, matched: true };
+        }
+
+        const { full, initials } = getPinyinForms(title);
+
+        if (initials.startsWith(lettersOnlyTerm)) {
+          return { item, index, score: 2, matched: true };
+        }
+
+        if (initials.includes(lettersOnlyTerm)) {
+          return { item, index, score: 3, matched: true };
+        }
+
+        if (full.startsWith(lettersOnlyTerm)) {
+          return { item, index, score: 4, matched: true };
+        }
+
+        if (full.includes(lettersOnlyTerm)) {
+          return { item, index, score: 5, matched: true };
+        }
+
+        return { item, index, score: Number.POSITIVE_INFINITY, matched: false };
+      })
+      .filter((entry) => entry.matched)
+      .sort((a, b) => (a.score === b.score ? a.index - b.index : a.score - b.score))
+      .map((entry) => entry.item);
+
+    return rankedMatches;
+  };
+
+  const updateLocalHistory = (term: string) => {
+    const trimmed = term.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    setSearchHistory((prev) => {
+      const next = [trimmed, ...prev.filter((item) => item !== trimmed)];
+      return next.slice(0, MAX_HISTORY_ITEMS);
+    });
+  };
 
   const handleSearch = async (searchText?: string) => {
     const term = typeof searchText === "string" ? searchText : keyword;
-    if (!term.trim()) {
-      Keyboard.dismiss();
+    const trimmedTerm = term.trim();
+
+    if (!trimmedTerm) {
+      if (!searchText) {
+        setResults([]);
+        setError(null);
+      }
+      if (!isTv) {
+        Keyboard.dismiss();
+      }
       return;
     }
-    Keyboard.dismiss();
+
+    if (!isTv) {
+      Keyboard.dismiss();
+    }
+
     setLoading(true);
     setError(null);
+
     try {
-      const response = await api.searchVideos(term);
-      if (response.results.length > 0) {
-        setResults(response.results);
-      } else {
+      const collapsedLowerTerm = trimmedTerm.toLowerCase().replace(/\s+/g, "");
+      const lettersOnlyTerm = collapsedLowerTerm.replace(/[^a-z]/g, "");
+      const isAlphabetic = lettersOnlyTerm.length > 0 && lettersOnlyTerm === collapsedLowerTerm;
+      const queryForApi = isAlphabetic ? lettersOnlyTerm : trimmedTerm;
+
+      const response = await api.searchVideos(queryForApi);
+      const filteredResults = filterResultsByKeyword(response.results, trimmedTerm);
+      setResults(filteredResults);
+
+      if (filteredResults.length === 0) {
         setError("没有找到相关内容");
+      } else {
+        setError(null);
+      }
+
+      updateLocalHistory(trimmedTerm);
+
+      try {
+        await SearchHistoryManager.add(trimmedTerm);
+      } catch (historyError) {
+        logger.warn("Failed to persist search history:", historyError);
       }
     } catch (err) {
       setError("搜索失败，请稍后重试。");
+      setResults([]);
       logger.info("Search failed:", err);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleClearInput = () => {
+    setKeyword("");
+    setResults([]);
+    setError(null);
+    textInputRef.current?.focus?.();
+  };
+
+  const handleDeleteLastCharacter = () => {
+    setKeyword((prev) => prev.slice(0, -1));
+    setError(null);
+  };
+
+  const handleKeyboardAppend = (value: string) => {
+    setKeyword((prev) => prev + value);
+    setError(null);
+  };
+
+  const handleSpecialKeyPress = (type: SpecialKeyType) => {
+    switch (type) {
+      case "space":
+        handleKeyboardAppend(" ");
+        break;
+      case "delete":
+        handleDeleteLastCharacter();
+        break;
+      case "clear":
+        handleClearInput();
+        break;
+      case "search":
+        handleSearch();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleHistorySelect = (value: string) => {
+    setKeyword(value);
+    handleSearch(value);
+  };
+
+  const handleSuggestionSelect = (value: string) => {
+    setKeyword(value);
+    handleSearch(value);
+  };
+
+  const handleClearHistory = async () => {
+    try {
+      await SearchHistoryManager.clear();
+      setSearchHistory([]);
+    } catch (historyError) {
+      logger.warn("Failed to clear search history:", historyError);
     }
   };
 
@@ -91,7 +324,7 @@ export default function SearchScreen() {
       ]);
       return;
     }
-    showRemoteModal('search');
+    showRemoteModal("search");
   };
 
   const renderItem = ({ item }: { item: SearchResult; index: number }) => (
@@ -106,11 +339,10 @@ export default function SearchScreen() {
     />
   );
 
-  // 动态样式
   const dynamicStyles = createResponsiveStyles(deviceType, spacing);
 
-  const renderSearchContent = () => (
-    <>
+  const renderSearchControls = () => (
+    <View>
       <View style={dynamicStyles.searchContainer}>
         <TouchableOpacity
           activeOpacity={1}
@@ -125,7 +357,7 @@ export default function SearchScreen() {
           <TextInput
             ref={textInputRef}
             style={dynamicStyles.input}
-            placeholder="搜索电影、剧集..."
+            placeholder="支持全拼拼音首字母搜索"
             placeholderTextColor="#888"
             value={keyword}
             onChangeText={setKeyword}
@@ -133,33 +365,171 @@ export default function SearchScreen() {
             onFocus={() => setIsInputFocused(true)}
             onBlur={() => setIsInputFocused(false)}
             returnKeyType="search"
+            autoCapitalize="none"
+            autoCorrect={false}
+            importantForAutofill="no"
           />
         </TouchableOpacity>
         <StyledButton style={dynamicStyles.searchButton} onPress={onSearchPress}>
-          <Search size={deviceType === 'mobile' ? 20 : 24} color="white" />
+          <Search size={deviceType === "mobile" ? 20 : 24} color="white" />
         </StyledButton>
-        {deviceType !== 'mobile' && (
+        {deviceType !== "mobile" && (
           <StyledButton style={dynamicStyles.qrButton} onPress={handleQrPress}>
-            <QrCode size={deviceType === 'tv' ? 24 : 20} color="white" />
+            <QrCode size={deviceType === "tv" ? 24 : 20} color="white" />
           </StyledButton>
         )}
       </View>
+    </View>
+  );
 
-      {loading ? (
-        <VideoLoadingAnimation showProgressBar={false} />
-      ) : error ? (
-        <View style={[commonStyles.center, { flex: 1 }]}>
+  const renderHistorySection = () => {
+    if (!isTv && searchHistory.length === 0) {
+      return null;
+    }
+
+    const displayHistory = isTv ? searchHistory : searchHistory.slice(0, 8);
+
+    return (
+      <View style={dynamicStyles.section}>
+        <View style={dynamicStyles.sectionHeader}>
+          <ThemedText style={dynamicStyles.sectionTitle}>搜索历史</ThemedText>
+          {searchHistory.length > 0 && (
+            <TouchableOpacity onPress={handleClearHistory}>
+              <ThemedText style={dynamicStyles.sectionActionText}>清除</ThemedText>
+            </TouchableOpacity>
+          )}
+        </View>
+        {searchHistory.length > 0 ? (
+          <View style={dynamicStyles.chipContainer}>
+            {displayHistory.map((item) => (
+              <StyledButton
+                key={item}
+                text={item}
+                variant="ghost"
+                onPress={() => handleHistorySelect(item)}
+                style={dynamicStyles.chip}
+                textStyle={dynamicStyles.chipText}
+              />
+            ))}
+          </View>
+        ) : (
+          isTv ? <ThemedText style={dynamicStyles.emptyHintText}>暂无搜索历史</ThemedText> : null
+        )}
+      </View>
+    );
+  };
+
+  const renderSuggestionsSection = () => {
+    if (!isTv || HOT_SEARCH_KEYWORDS.length === 0) {
+      return null;
+    }
+
+    return (
+      <View style={dynamicStyles.section}>
+        <ThemedText style={dynamicStyles.sectionTitle}>猜你可能在找</ThemedText>
+        <View style={dynamicStyles.chipContainer}>
+          {HOT_SEARCH_KEYWORDS.map((item) => (
+            <StyledButton
+              key={item}
+              text={item}
+              variant="ghost"
+              onPress={() => handleSuggestionSelect(item)}
+              style={dynamicStyles.chip}
+              textStyle={dynamicStyles.chipText}
+            />
+          ))}
+        </View>
+      </View>
+    );
+  };
+
+  const renderKeyboardSection = () => {
+    if (!isTv) {
+      return null;
+    }
+
+    return (
+      <View style={dynamicStyles.section}>
+        <ThemedText style={dynamicStyles.sectionTitle}>拼音键盘</ThemedText>
+        <View style={dynamicStyles.keyboardContainer}>
+          {KEYBOARD_KEYS.map((key) => (
+            <StyledButton
+              key={key}
+              text={key}
+              variant="ghost"
+              onPress={() => handleKeyboardAppend(key)}
+              style={dynamicStyles.keyboardKey}
+              textStyle={dynamicStyles.keyboardKeyText}
+            />
+          ))}
+        </View>
+        <View style={dynamicStyles.keyboardSpecialRow}>
+          {SPECIAL_KEY_CONFIG.map((item) => (
+            <StyledButton
+              key={item.type}
+              text={item.label}
+              variant="ghost"
+              onPress={() => handleSpecialKeyPress(item.type)}
+              style={dynamicStyles.keyboardSpecialKey}
+              textStyle={dynamicStyles.keyboardSpecialKeyText}
+            />
+          ))}
+        </View>
+      </View>
+    );
+  };
+
+  const renderResultsContent = () => {
+    if (loading) {
+      return (
+        <View style={dynamicStyles.resultsPlaceholder}>
+          <VideoLoadingAnimation showProgressBar={false} />
+        </View>
+      );
+    }
+
+    if (error) {
+      return (
+        <View style={[dynamicStyles.resultsPlaceholder, commonStyles.center]}>
           <ThemedText style={dynamicStyles.errorText}>{error}</ThemedText>
         </View>
-      ) : (
-        <CustomScrollView
-          data={results}
-          renderItem={renderItem}
-          loading={loading}
-          error={error}
-          emptyMessage="输入关键词开始搜索"
-        />
-      )}
+      );
+    }
+
+    if (results.length === 0) {
+      return (
+        <View style={[dynamicStyles.resultsPlaceholder, commonStyles.center]}>
+          <ThemedText style={dynamicStyles.emptyText}>输入关键词开始搜索</ThemedText>
+        </View>
+      );
+    }
+
+    return <CustomScrollView data={results} renderItem={renderItem} />;
+  };
+
+  const renderResultsSection = () => (
+    <View style={dynamicStyles.resultsContainer}>
+      <View style={dynamicStyles.resultsHeader}>
+        <ThemedText style={dynamicStyles.sectionTitle}>搜索结果</ThemedText>
+        {keyword.trim() && results.length > 0 && !loading && !error ? (
+          <ThemedText style={dynamicStyles.resultsCountText}>共 {results.length} 个结果</ThemedText>
+        ) : null}
+      </View>
+      {renderResultsContent()}
+    </View>
+  );
+
+  const renderSearchContent = () => (
+    <>
+      <View style={dynamicStyles.contentWrapper}>
+        <View style={dynamicStyles.sidebar}>
+          {renderSearchControls()}
+          {renderHistorySection()}
+          {renderSuggestionsSection()}
+          {renderKeyboardSection()}
+        </View>
+        <View style={dynamicStyles.resultsWrapper}>{renderResultsSection()}</View>
+      </View>
       <RemoteControlModal />
     </>
   );
@@ -170,8 +540,7 @@ export default function SearchScreen() {
     </ThemedView>
   );
 
-  // 根据设备类型决定是否包装在响应式导航中
-  if (deviceType === 'tv') {
+  if (deviceType === "tv") {
     return content;
   }
 
@@ -184,56 +553,156 @@ export default function SearchScreen() {
 }
 
 const createResponsiveStyles = (deviceType: string, spacing: number) => {
-  const isMobile = deviceType === 'mobile';
+  const isMobile = deviceType === "mobile";
+  const isTv = deviceType === "tv";
   const minTouchTarget = DeviceUtils.getMinTouchTargetSize();
+  const inputHeight = isTv ? 64 : isMobile ? minTouchTarget : 56;
 
   return StyleSheet.create({
     container: {
       flex: 1,
-      paddingTop: deviceType === 'tv' ? 50 : 0,
+      paddingTop: isTv ? 40 : isMobile ? spacing / 2 : spacing,
+      paddingHorizontal: isTv ? spacing * 2 : spacing,
+    },
+    contentWrapper: {
+      flex: 1,
+      flexDirection: isTv ? "row" : "column",
+      paddingTop: isTv ? spacing : spacing / 2,
+    },
+    sidebar: {
+      width: isTv ? 420 : "100%",
+      marginRight: isTv ? spacing * 1.5 : 0,
+      marginBottom: isTv ? 0 : spacing,
     },
     searchContainer: {
       flexDirection: "row",
-      paddingHorizontal: spacing,
-      marginBottom: spacing,
       alignItems: "center",
-      paddingTop: isMobile ? spacing / 2 : 0,
+      marginBottom: spacing,
     },
     inputContainer: {
       flex: 1,
-      height: isMobile ? minTouchTarget : 50,
+      height: inputHeight,
       backgroundColor: "#2c2c2e",
-      borderRadius: isMobile ? 8 : 8,
-      marginRight: spacing / 2,
+      borderRadius: isTv ? 16 : 10,
+      paddingHorizontal: spacing,
       borderWidth: 2,
       borderColor: "transparent",
       justifyContent: "center",
     },
     input: {
       flex: 1,
-      paddingHorizontal: spacing,
       color: "white",
-      fontSize: isMobile ? 16 : 18,
+      fontSize: isTv ? 22 : isMobile ? 16 : 18,
     },
     searchButton: {
-      width: isMobile ? minTouchTarget : 50,
-      height: isMobile ? minTouchTarget : 50,
+      width: isTv ? inputHeight : isMobile ? minTouchTarget : 50,
+      height: inputHeight,
       justifyContent: "center",
       alignItems: "center",
-      borderRadius: isMobile ? 8 : 8,
-      marginRight: deviceType !== 'mobile' ? spacing / 2 : 0,
+      borderRadius: isTv ? 16 : 10,
+      marginLeft: spacing / 2,
     },
     qrButton: {
-      width: isMobile ? minTouchTarget : 50,
-      height: isMobile ? minTouchTarget : 50,
+      width: isTv ? inputHeight : isMobile ? minTouchTarget : 50,
+      height: inputHeight,
       justifyContent: "center",
       alignItems: "center",
-      borderRadius: isMobile ? 8 : 8,
+      borderRadius: isTv ? 16 : 10,
+      marginLeft: spacing / 2,
+    },
+    section: {
+      marginTop: isTv ? spacing * 1.5 : spacing,
+    },
+    sectionHeader: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: spacing / 2,
+    },
+    sectionTitle: {
+      color: "white",
+      fontSize: isTv ? 24 : isMobile ? 16 : 18,
+      fontWeight: "600",
+    },
+    sectionActionText: {
+      color: Colors.dark.link,
+      fontSize: isTv ? 18 : 14,
+    },
+    chipContainer: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+    },
+    chip: {
+      marginRight: spacing / 2,
+      marginBottom: spacing / 2,
+    },
+    chipText: {
+      fontSize: isTv ? 20 : isMobile ? 14 : 16,
+    },
+    emptyHintText: {
+      color: "#888",
+      fontSize: isTv ? 18 : 14,
+    },
+    keyboardContainer: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      marginTop: spacing,
+    },
+    keyboardKey: {
+      width: isTv ? 72 : 56,
+      height: isTv ? 56 : 44,
+      marginRight: spacing / 2,
+      marginBottom: spacing / 2,
+    },
+    keyboardKeyText: {
+      fontSize: isTv ? 22 : 16,
+    },
+    keyboardSpecialRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      marginTop: spacing / 2,
+    },
+    keyboardSpecialKey: {
+      width: isTv ? 120 : 96,
+      height: isTv ? 56 : 44,
+      marginRight: spacing / 2,
+      marginBottom: spacing / 2,
+    },
+    keyboardSpecialKeyText: {
+      fontSize: isTv ? 20 : 16,
+    },
+    resultsWrapper: {
+      flex: 1,
+      marginLeft: isTv ? spacing * 1.5 : 0,
+      marginTop: isTv ? 0 : spacing,
+    },
+    resultsContainer: {
+      flex: 1,
+    },
+    resultsHeader: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: spacing / 2,
+    },
+    resultsCountText: {
+      color: "#ccc",
+      fontSize: isTv ? 18 : 14,
+    },
+    resultsPlaceholder: {
+      flex: 1,
+      justifyContent: "center",
+      alignItems: "center",
+      paddingHorizontal: spacing,
     },
     errorText: {
       color: "red",
-      fontSize: isMobile ? 14 : 16,
+      fontSize: isTv ? 18 : isMobile ? 14 : 16,
       textAlign: "center",
+    },
+    emptyText: {
+      color: "#888",
+      fontSize: isTv ? 18 : 14,
     },
   });
 };

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "react-native": "npm:react-native-tvos@~0.81.4-0"
   },
   "dependencies": {
+    "@expo/metro-runtime": "~6.1.2",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-cookies/cookies": "^6.2.1",
     "@react-navigation/native": "^7.1.8",
-    "@expo/metro-runtime": "~6.1.2",
     "expo": "~54.0.9",
     "expo-build-properties": "~1.0.9",
     "expo-constants": "~18.0.9",
@@ -46,6 +46,7 @@
     "expo-video": "~3.0.11",
     "expo-web-browser": "~15.0.7",
     "lucide-react-native": "^0.523.0",
+    "pinyin-pro": "^3.27.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "npm:react-native-tvos@~0.81.4-0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,11 +933,6 @@
   dependencies:
     tslib "^2.4.0"
 
-"@epic-web/invariant@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
-  integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
-
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz#7308df158e064f0dd8b8fdb58aa14fa2a7f913b3"
@@ -3627,14 +3622,6 @@ create-jest@^29.7.0:
     jest-config "^29.7.0"
     jest-util "^29.7.0"
     prompts "^2.0.1"
-
-cross-env@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-10.0.0.tgz#ba25823cfa1ed6af293dcded8796fa16cd162456"
-  integrity sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==
-  dependencies:
-    "@epic-web/invariant" "^1.0.0"
-    cross-spawn "^7.0.6"
 
 cross-fetch@^3.1.5:
   version "3.2.0"
@@ -7335,6 +7322,11 @@ picomatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
+pinyin-pro@^3.27.0:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/pinyin-pro/-/pinyin-pro-3.27.0.tgz#b13e60a2383067e5b1231106f7939a2c7591be29"
+  integrity sha512-Osdgjwe7Rm17N2paDMM47yW+jUIUH3+0RGo8QP39ZTLpTaJVDK0T58hOLaMQJbcMmAebVuK2ePunTEVEx1clNQ==
 
 pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.7"


### PR DESCRIPTION
## Summary
- redesign the TV search screen with a sidebar that mirrors the reference layout, including history, hot keywords, and an on-screen pinyin keyboard
- hook the search experience into persisted search history so users can recall and clear queries from the new UI
- keep the pinyin-aware search flow while adjusting API queries and state handling to match the refreshed layout

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d24f59e3748322927a874c02785b47