### PR TITLE
fix: add autoFocus prop to RelatedSeries component

### DIFF
--- a/components/RelatedSeries.tsx
+++ b/components/RelatedSeries.tsx
@@ -10,9 +10,10 @@ import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
 interface RelatedSeriesProps {
   title: string;
   onFocus?: (item: any) => void;
+  autoFocus?: boolean;
 }
 
-const RelatedSeries: React.FC<RelatedSeriesProps> = ({ title, onFocus }) => {
+const RelatedSeries: React.FC<RelatedSeriesProps> = ({ title, onFocus, autoFocus }) => {
   const [related, setRelated] = React.useState<any[]>([]);
   const [loading, setLoading] = React.useState(true);
   const { deviceType } = useResponsiveLayout();
@@ -37,13 +38,14 @@ const RelatedSeries: React.FC<RelatedSeriesProps> = ({ title, onFocus }) => {
   }, [title]);
 
   const renderItem = React.useCallback(
-    ({ item }: { item: any }) => (
+    ({ item, index }: { item: any; index: number }) => (
       <VideoCard
         {...item}
         onFocus={() => onFocus?.(item)}
+        hasTVPreferredFocus={autoFocus && index === 0}
       />
     ),
-    [onFocus]
+    [onFocus, autoFocus]
   );
 
   const flashListConfig = useMemo(() => 


### PR DESCRIPTION
Added the missing autoFocus prop to RelatedSeriesProps interface and implemented the focus logic in RelatedSeries component to fix the TypeScript error in app/related.tsx.