### PR TITLE
feat: gate performance monitor to development mode

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,8 +30,8 @@ SplashScreen.preventAutoHideAsync();
 export default function RootLayout() {
   const colorScheme = "dark";
 
-  // Performance tracking (enabled by default)
-  usePerformanceMonitor(true);
+  // Performance tracking (only in development)
+  usePerformanceMonitor(__DEV__);
 
   useEffect(() => {
     ConsoleOptimizer.initialize();

--- a/hooks/usePerformanceMonitor.ts
+++ b/hooks/usePerformanceMonitor.ts
@@ -6,7 +6,8 @@ import { PerformanceMonitor } from '@/utils/PerformanceMonitor';
  */
 export function usePerformanceMonitor(enabled = true) {
   useEffect(() => {
-    if (!enabled) return;
+    // Only allow performance monitoring in development mode
+    if (!enabled || !__DEV__) return;
 
     PerformanceMonitor.start();
 


### PR DESCRIPTION
- Updated `RootLayout` to only enable `usePerformanceMonitor` when `__DEV__` is true.
- Added a safeguard within `usePerformanceMonitor` hook to prevent accidental activation in production.
- This ensures that performance-heavy loops (`setInterval` and `requestAnimationFrame`) in `PerformanceMonitor` do not run in production builds.