### PR TITLE
fix(services): preserve activeLoads in ImagePreloader when clearing q…

### DIFF
--- a/services/ImagePreloader.ts
+++ b/services/ImagePreloader.ts
@@ -14,27 +14,38 @@ export class ImagePreloader {
    */
   static async preload(urls: string[]): Promise<void> {
     for (const url of urls) {
+      // 如果队列中已经有该 URL，说明正在加载或已排队，跳过
       if (!url || this.loadingQueue.has(url)) continue;
 
       this.loadingQueue.add(url);
 
-      // 限制并发数
-      while (this.activeLoads >= this.maxConcurrent) {
-        await new Promise(resolve => setTimeout(resolve, 50));
-      }
-
-      this.activeLoads++;
-
+      let incremented = false;
       try {
-        await Image.prefetch(url);
-        if (__DEV__) {
-          // console.debug(`[ImagePreloader] Preloaded: ${url}`);
+        // 限制并发数
+        while (this.activeLoads >= this.maxConcurrent) {
+          await new Promise(resolve => setTimeout(resolve, 50));
+          // 如果等待期间队列被清空了（调用了 clear），则停止当前任务
+          if (!this.loadingQueue.has(url)) return;
         }
+
+        // 再次检查，防止在等待并发锁期间调用了 clear()
+        if (!this.loadingQueue.has(url)) return;
+
+        this.activeLoads++;
+        incremented = true;
+
+        await Image.prefetch(url);
       } catch (error) {
         // 静默失败，不影响主流程
       } finally {
-        this.activeLoads--;
+        const wasInQueue = this.loadingQueue.has(url);
+        if (incremented) {
+          this.activeLoads = Math.max(0, this.activeLoads - 1);
+        }
         this.loadingQueue.delete(url);
+
+        // 如果在处理过程中 url 从队列中消失了（说明调用了 clear），则停止此批次的后续预加载
+        if (!wasInQueue) return;
       }
     }
   }
@@ -65,6 +76,6 @@ export class ImagePreloader {
    */
   static clear(): void {
     this.loadingQueue.clear();
-    this.activeLoads = 0;
+    // 注意：不在这里将 activeLoads 置为 0，以防止正在进行的请求完成时导致计数器变为负数
   }
 }

--- a/services/__tests__/ImagePreloader.test.ts
+++ b/services/__tests__/ImagePreloader.test.ts
@@ -1,0 +1,110 @@
+import { ImagePreloader } from '../ImagePreloader';
+import { Image } from 'expo-image';
+
+jest.mock('expo-image', () => ({
+  Image: {
+    prefetch: jest.fn(),
+  },
+}));
+
+describe('ImagePreloader', () => {
+  beforeEach(() => {
+    // Reset internal state of ImagePreloader
+    ImagePreloader.clear();
+    (ImagePreloader as any).activeLoads = 0; // Force reset for tests
+    jest.clearAllMocks();
+  });
+
+  it('should not have negative activeLoads after clear() and request completion', async () => {
+    let resolvePrefetch: (value: boolean) => void = () => {};
+    const prefetchPromise = new Promise<boolean>((resolve) => {
+      resolvePrefetch = resolve;
+    });
+
+    (Image.prefetch as jest.Mock).mockReturnValue(prefetchPromise);
+
+    // Start a preload
+    const preloadPromise = ImagePreloader.preload(['http://example.com/image.jpg']);
+
+    // Wait for the async loop to reach the prefetch call
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Check if activeLoads is 1
+    expect((ImagePreloader as any).activeLoads).toBe(1);
+
+    // Call clear()
+    ImagePreloader.clear();
+    // activeLoads should NOT be 0 yet, as the request is still in flight
+    expect((ImagePreloader as any).activeLoads).toBe(1);
+
+    // Resolve the prefetch
+    resolvePrefetch(true);
+    await preloadPromise;
+
+    // Check activeLoads - now it should be 0
+    expect((ImagePreloader as any).activeLoads).toBe(0);
+  });
+
+  it('should respect maxConcurrent across multiple preload calls', async () => {
+    const prefetchPromises: Array<(value: boolean) => void> = [];
+    (Image.prefetch as jest.Mock).mockImplementation(() => {
+        return new Promise((resolve) => {
+            prefetchPromises.push(resolve);
+        });
+    });
+
+    // Start 5 concurrent preload calls (each with one URL)
+    const urls = ['url1', 'url2', 'url3', 'url4', 'url5'];
+    const preloadPromises = urls.map(url => ImagePreloader.preload([url]));
+
+    // Wait long enough for the async loops to attempt starting
+    for(let i=0; i<10; i++) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Should have maxConcurrent (3) active loads
+    expect((ImagePreloader as any).activeLoads).toBe(3);
+    expect(prefetchPromises.length).toBe(3);
+
+    // Resolve ALL current ones to let others proceed
+    while (prefetchPromises.length > 0) {
+        const resolve = prefetchPromises.shift()!;
+        resolve(true);
+    }
+
+    // Wait for remaining ones to start
+    for(let i=0; i<10; i++) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Now all 5 should have been processed or are active
+    // Since we resolved 3, the remaining 2 should have started.
+    expect(Image.prefetch).toHaveBeenCalledTimes(5);
+
+    // Clean up remaining
+    while (prefetchPromises.length > 0) {
+        const resolve = prefetchPromises.shift()!;
+        resolve(true);
+    }
+
+    await Promise.all(preloadPromises);
+    expect((ImagePreloader as any).activeLoads).toBe(0);
+  }, 10000);
+
+  it('should stop preloading remaining URLs in a batch after clear()', async () => {
+    (Image.prefetch as jest.Mock).mockImplementation(() => Promise.resolve(true));
+
+    // We want to hook into Image.prefetch to call clear()
+    (Image.prefetch as jest.Mock).mockImplementationOnce(async () => {
+        ImagePreloader.clear();
+        return true;
+    });
+
+    await ImagePreloader.preload(['url1', 'url2', 'url3']);
+
+    // url1 should have been called, but url2 and url3 should NOT
+    expect(Image.prefetch).toHaveBeenCalledTimes(1);
+    expect(Image.prefetch).toHaveBeenCalledWith('url1');
+    expect((ImagePreloader as any).activeLoads).toBe(0);
+  });
+});


### PR DESCRIPTION
…ueue

- Removed `this.activeLoads = 0` from `ImagePreloader.clear()` to prevent the counter from becoming negative when in-flight requests complete.
- Enhanced `preload()` to handle `clear()` calls by checking `loadingQueue` membership.
- Added safety check to ensure `activeLoads` never drops below 0.
- Added comprehensive unit tests in `services/__tests__/ImagePreloader.test.ts`.

This fix ensures that the concurrency guard remains effective for subsequent preloading batches even after a screen unmount or manual queue clear.